### PR TITLE
使用 gcc-arm-8.3 对 onnx-1.15.1 编译动态库

### DIFF
--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache build result for ${{ env.ONNXRUNTIME_VERSION }}
         id: cache-build-result
-        uses: actions/cache@v2
+        uses: actions/cache@vv
         with:
           path: onnxruntime-linux-arm-${{ env.ONNXRUNTIME_VERSION }}
           key: onnxruntime-arm-linux-${{ env.ONNXRUNTIME_VERSION }}-cache-v2

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -49,18 +49,18 @@ jobs:
         uses: actions/cache@v3
         with:
           path: toolchain
-          key: gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf
+          key: gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf
 
       - name: Download toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -SL -O https://huggingface.co/csukuangfj/arm-linux-gcc/resolve/main/gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz
+          curl -SL -O https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64_be-linux-gnu.tar.xz
           git lfs install
           mkdir $GITHUB_WORKSPACE/toolchain
 
-          tar xvf ./gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
-          rm -v gcc-arm-9.2-2019.12-x86_64-arm-none-linux-gnueabihf.tar.xz
+          tar xvf ./gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf.tar.xz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
+          rm -v gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf.tar.xz
 
       - name: Download protoc
         if: steps.cache-build-result.outputs.cache-hit != 'true'

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -55,7 +55,7 @@ jobs:
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -SL -O https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-aarch64_be-linux-gnu.tar.xz
+          curl -SL -O https://developer.arm.com/-/media/Files/downloads/gnu-a/8.3-2019.03/binrel/gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz
           git lfs install
           mkdir $GITHUB_WORKSPACE/toolchain
 

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -90,14 +90,14 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin"  >> "$GITHUB_PATH"
           ls -lh "$GITHUB_WORKSPACE/toolchain/bin"
 
-          echo "CC=arm-none-linux-gnueabihf-gcc" >> "$GITHUB_ENV"
+          echo "CC=arm-linux-gnueabihf" >> "$GITHUB_ENV"
           echo "CXX=arm-none-linux-gnueabihf-g++" >> "$GITHUB_ENV"
 
       - name: Display toolchain info
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          arm-none-linux-gnueabihf-gcc --version
+          arm-linux-gnueabihf --version
 
       - name: Display protoc info for ${{ env.ONNXRUNTIME_VERSION }}
         if: steps.cache-build-result.outputs.cache-hit != 'true'

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache build result for ${{ env.ONNXRUNTIME_VERSION }}
         id: cache-build-result
-        uses: actions/cache@vv
+        uses: actions/cache@v3
         with:
           path: onnxruntime-linux-arm-${{ env.ONNXRUNTIME_VERSION }}
           key: onnxruntime-arm-linux-${{ env.ONNXRUNTIME_VERSION }}-cache-v2

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -90,14 +90,14 @@ jobs:
           echo "$GITHUB_WORKSPACE/bin"  >> "$GITHUB_PATH"
           ls -lh "$GITHUB_WORKSPACE/toolchain/bin"
 
-          echo "CC=arm-linux-gnueabihf" >> "$GITHUB_ENV"
-          echo "CXX=arm-none-linux-gnueabihf-g++" >> "$GITHUB_ENV"
+          echo "CC=arm-linux-gnueabihf-gcc" >> "$GITHUB_ENV"
+          echo "CXX=arm-linux-gnueabihf-g++" >> "$GITHUB_ENV"
 
       - name: Display toolchain info
         if: steps.cache-build-result.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          arm-linux-gnueabihf --version
+          arm-linux-gnueabihf-gcc --version
 
       - name: Display protoc info for ${{ env.ONNXRUNTIME_VERSION }}
         if: steps.cache-build-result.outputs.cache-hit != 'true'

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: toolchain
-          key: gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf
+          key: gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf
 
       - name: Download toolchain
         if: steps.cache-toolchain.outputs.cache-hit != 'true'
@@ -59,8 +59,8 @@ jobs:
           git lfs install
           mkdir $GITHUB_WORKSPACE/toolchain
 
-          tar xvf ./gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf.tar.xz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
-          rm -v gcc-arm-8.3-2019.03-x86_64-arm-none-linux-gnueabihf.tar.xz
+          tar xvf ./gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz --strip-components 1 -C $GITHUB_WORKSPACE/toolchain
+          rm -v gcc-arm-8.3-2019.03-x86_64-arm-linux-gnueabihf.tar.xz
 
       - name: Download protoc
         if: steps.cache-build-result.outputs.cache-hit != 'true'

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -166,6 +166,7 @@ jobs:
             --cmake_extra_defines CMAKE_INSTALL_PREFIX=$build_dir/install/ \
             --cmake_extra_defines CMAKE_SYSTEM_NAME=Linux \
             --cmake_extra_defines CMAKE_SYSTEM_PROCESSOR=armv7l \
+            --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 \
             --target install \
             --parallel \
             --skip_tests

--- a/.github/workflows/arm-linux-gnueabihf.yaml
+++ b/.github/workflows/arm-linux-gnueabihf.yaml
@@ -120,6 +120,15 @@ jobs:
           python3 -m pip install cmake
           cmake --version
 
+      - name: Install updated CMake
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get install -y cmake
+          cmake --version
+
       - name: apply patch
         shell: bash
         run: |


### PR DESCRIPTION
我在RK1126上使用 sherpa-onnx 时，发现官方镜像 gcc = 8.3，GLIBC = 2.28

在交叉编译 armv7l 版本时产生报错： onnxruntime.so 使用了 GLIBC_2.29 的函数

进一步研究发现 onnxruntime 官方是支持 gcc < 9，GLIBC <= 2.28 的，因此对此工作流进行调整，以适应 armv7l 平台

附运行成功截图
![sherpa-onnx-armv7l](https://github.com/user-attachments/assets/69967432-d78a-422b-9ec3-0ce4ee9e0bf0)
